### PR TITLE
Added second wide residual network

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ If you have a high-quality tutorial or project to add, please open a PR.
 - [VGG-CAM](https://github.com/tdeboissiere/VGG16CAM-keras)
 - [t-SNE of image CNN fc7 activations](https://github.com/ml4a/ml4a-guides/blob/master/notebooks/tsne-images.ipynb)
 - [VGG16 Deconvolution network](https://github.com/tdeboissiere/Kaggle/tree/master/StateFarm/DeconvNet)
-- [Wide Residual Networks (with pre-trained weights)](https://github.com/asmith26/wide_resnets_keras)
+- Wide Residual Networks (with pre-trained weights): [1](https://github.com/asmith26/wide_resnets_keras) - [2](https://github.com/titu1994/Wide-Residual-Networks)
 - [Ultrasound nerve segmentation](https://github.com/jocicmarko/ultrasound-nerve-segmentation)
 
 ### Creative visual applications


### PR DESCRIPTION
Added my implementation of the Wide Residual Network, which achieves similar classification accuracy to the scores described in the original paper.

Contains a script to construct WRN's of any size, with pre-trained weights for WRN-16-8 (93.68%, compared to 95.19% in paper) and WRN-28-8 (95.08%, compared to 95.83% in paper for WRN-28-10).