### PR TITLE
Add Densely Connected Convolutional Networks

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ If you have a high-quality tutorial or project to add, please open a PR.
 - Wide Residual Networks (with pre-trained weights): [1](https://github.com/asmith26/wide_resnets_keras) - [2](https://github.com/titu1994/Wide-Residual-Networks)
 - [Ultrasound nerve segmentation](https://github.com/jocicmarko/ultrasound-nerve-segmentation)
 - [DeepMask object segmentation](https://github.com/abbypa/NNProject_DeepMask)
+- [Densely Connected Convolutional Networks](https://github.com/tdeboissiere/DeepLearningImplementations/tree/master/DenseNet)
 
 ### Creative visual applications
 


### PR DESCRIPTION
Adding a keras implementation of  [Densely Connected Convolutional Networks](http://arxiv.org/abs/1608.06993)

N.B: The link above is the paper, the implementation is at (https://github.com/tdeboissiere/DeepLearningImplementations/tree/master/DenseNet)