### PR TITLE
Added Snapshot Ensemble and second DenseNet with weights

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,8 @@ If you have a high-quality tutorial or project to add, please open a PR.
 - Wide Residual Networks (with pre-trained weights): [1](https://github.com/asmith26/wide_resnets_keras) - [2](https://github.com/titu1994/Wide-Residual-Networks)
 - [Ultrasound nerve segmentation](https://github.com/jocicmarko/ultrasound-nerve-segmentation)
 - [DeepMask object segmentation](https://github.com/abbypa/NNProject_DeepMask)
-- [Densely Connected Convolutional Networks](https://github.com/tdeboissiere/DeepLearningImplementations/tree/master/DenseNet)
+- Densely Connected Convolutional Networks: [1](https://github.com/tdeboissiere/DeepLearningImplementations/tree/master/DenseNet) - [2](https://github.com/titu1994/DenseNet)
+- [Snapshot Ensembles: Train 1, Get M for Free](https://github.com/titu1994/Snapshot-Ensembles)
 
 ### Creative visual applications
 


### PR DESCRIPTION
Contains two updates:

1. Adds a second DenseNet, which contains weights for DenseNet-40 trained on CIFAR-10 
2. Adds Snapshot Ensembles, with snapshot weights of WRN-16-4 model for CIFAR-10 and CIFAR-100.