### PR TITLE
Add heatmap

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ If you have a high-quality tutorial or project to add, please open a PR.
 - ResNet 50 (with pre-trained weights): [1](https://github.com/fchollet/keras/pull/3266/files) - [2](https://github.com/raghakot/keras-resnet)
 - [FractalNet](https://github.com/snf/keras-fractalnet)
 - [AlexNet, VGG 16, VGG 19, and class heatmap visualization](https://github.com/heuritech/convnets-keras)
+- [Any model and class heatmap visualization](https://github.com/gabrieldemarmiesse/heatmaps)
 - [Visual-Semantic Embedding](https://github.com/awentzonline/keras-visual-semantic-embedding)
 - Variational Autoencoder: [with deconvolutions](https://github.com/fchollet/keras/blob/master/examples/variational_autoencoder_deconv.py) - [with upsampling](https://github.com/fchollet/keras/blob/master/examples/variational_autoencoder.py)
 - [Visual question answering](https://github.com/avisingh599/visual-qa)

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ If you have a high-quality tutorial or project to add, please open a PR.
 - [VGG 19 (with pre-trained weights)](https://gist.github.com/baraldilorenzo/8d096f48a1be4a2d660d)
 - ResNet 50 (with pre-trained weights): [1](https://github.com/fchollet/keras/pull/3266/files) - [2](https://github.com/raghakot/keras-resnet)
 - [FractalNet](https://github.com/snf/keras-fractalnet)
-- [Any model and class heatmap visualization](https://github.com/gabrieldemarmiesse/heatmaps)
+- [Class heatmap visualization for any model](https://github.com/gabrieldemarmiesse/heatmaps)
 - [Visual-Semantic Embedding](https://github.com/awentzonline/keras-visual-semantic-embedding)
 - Variational Autoencoder: [with deconvolutions](https://github.com/fchollet/keras/blob/master/examples/variational_autoencoder_deconv.py) - [with upsampling](https://github.com/fchollet/keras/blob/master/examples/variational_autoencoder.py)
 - [Visual question answering](https://github.com/avisingh599/visual-qa)

--- a/README.md
+++ b/README.md
@@ -69,7 +69,6 @@ If you have a high-quality tutorial or project to add, please open a PR.
 - [VGG 19 (with pre-trained weights)](https://gist.github.com/baraldilorenzo/8d096f48a1be4a2d660d)
 - ResNet 50 (with pre-trained weights): [1](https://github.com/fchollet/keras/pull/3266/files) - [2](https://github.com/raghakot/keras-resnet)
 - [FractalNet](https://github.com/snf/keras-fractalnet)
-- [AlexNet, VGG 16, VGG 19, and class heatmap visualization](https://github.com/heuritech/convnets-keras)
 - [Any model and class heatmap visualization](https://github.com/gabrieldemarmiesse/heatmaps)
 - [Visual-Semantic Embedding](https://github.com/awentzonline/keras-visual-semantic-embedding)
 - Variational Autoencoder: [with deconvolutions](https://github.com/fchollet/keras/blob/master/examples/variational_autoencoder_deconv.py) - [with upsampling](https://github.com/fchollet/keras/blob/master/examples/variational_autoencoder.py)


### PR DESCRIPTION
Hi,

I saw that there was a mention of the `heuritech/convnets-keras` repository in the Keras resources.
Since this repo isn't updated anymore and provide quite some dead links in the README.md, I wanted to share my repository that build upon their work. 

Their repo provide keras models that produces heatmaps for AlexNet and VGG models. I made their algorithm work with nearly any model possible (so users that also try with their custom models in addition of all the models available in `keras/applications`) and increase the resolution by 4 when the classification network uses a flatten layer (I replace the maxpool by a dilated convolution).