### PR TITLE
Add link to imgclsmob repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ If you have a high-quality tutorial or project to add, please open a PR.
 - [Snapshot Ensembles: Train 1, Get M for Free](https://github.com/titu1994/Snapshot-Ensembles)
 - [Single Shot MultiBox Detector](https://github.com/rykov8/ssd_keras)
 - [Popular Image Segmentation Models : FCN, Segnet, U-Net etc. ](https://github.com/divamgupta/image-segmentation-keras)
+- [Pretrained classification models for Keras with MXNet backend](https://github.com/osmr/imgclsmob)
 
 ### Creative visual applications
 


### PR DESCRIPTION
Please, add a link to the `imgclsmob` repo with a collection of classification models for Keras with MXNet backend